### PR TITLE
fix toDate using the UTC timestamp for determining offset

### DIFF
--- a/src/toDate/index.js
+++ b/src/toDate/index.js
@@ -156,7 +156,7 @@ export default function toDate(argument, dirtyOptions) {
     if (dateStrings.timezone || options.timeZone) {
       offset = tzParseTimezone(
         dateStrings.timezone || options.timeZone,
-        new Date(timestamp + time)
+        date
       )
       if (isNaN(offset)) {
         return new Date(NaN)

--- a/src/toDate/test.js
+++ b/src/toDate/test.js
@@ -246,6 +246,13 @@ describe('toDate', function() {
         var result = toDate('2014-10-25T13:46:20 UTC')
         assert.deepEqual(result, new Date('2014-10-25T13:46:20Z'))
       })
+
+      it('uses the argument Date when determining offset', function() {
+        var result = toDate('2019-04-06T23:45:00', {
+          timeZone: 'Australia/Sydney'
+        })
+        assert.deepEqual(result, new Date('2019-04-06T12:45:00.000Z'))
+      })
     })
 
     describe('failure', function() {


### PR DESCRIPTION
This bug was quite subtle,  but it appeared when I was doing

```js
const foo = new Date('2019-04-06 23:45'
zonedTimeToUtc(foo), 'Australia/Sydney')
```

Which,  as my timezone _is_ `Australia/Sydney`,  should have returned the same date.   Instead it returned `2019-04-07 00:45`.

As this date is around DST (`2019-04-07 3:00`),  I knew that was likely a root cause.
But `tzParseTimezone` was giving the right offset when I called it manually.

I then realized that `tzParseTimezone` in `toDate` is being called with `new Date(timestamp + time)`. On investigation,  that is the local-time removed date (e.g `2019-04-06T23:45:00.000Z`).
Which is `07/04/2019, 9:45:00 am` in Australia.

That is **PAST** the DST change-over time; unlike my actual date `foo`, which is **BEFORE** the DST change-over time.

This likely needs better tests.