### PR TITLE
fix uctToZonedTime during timezone changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ Libraries like Moment and Luxon, which provide their own date time classes, mana
 zone values internally. Sine `date-fns` always returns a plain JS Date, which implicitly has the current
 system's time zone, helper functions are provided for handling common time zone related use cases.
 
+<div align="center">
+  <i>date-fns-tz is sponsored by the following partner, please help to support us by taking a look.</i>
+  <a href="https://tracking.gitads.io/?repo=date-fns-tz">
+    <img src="https://images.gitads.io/date-fns-tz" alt="" />
+  </a>
+</div>
+
 ## Time Zone Helpers
 
 To discuss the usage of the time zone helpers let's assume we're writing a system where administrators set

--- a/src/utcToZonedTime/index.js
+++ b/src/utcToZonedTime/index.js
@@ -40,7 +40,7 @@ export default function utcToZonedTime(dirtyDate, timeZone, options) {
     date.getUTCMilliseconds()
   )
   // We just need to apply the offset indicated by the time zone to this localized date
-  var offsetMilliseconds = tzParseTimezone(timeZone, date)
+  var offsetMilliseconds = tzParseTimezone(timeZone, utcDate)
 
   return offsetMilliseconds
     ? subMilliseconds(utcDate, offsetMilliseconds)

--- a/src/utcToZonedTime/test.js
+++ b/src/utcToZonedTime/test.js
@@ -64,4 +64,39 @@ describe('utcToZonedTime', function() {
       '2020-01-23T00:00:00.000'
     )
   })
+
+  it('retuns the correct date/time during time change', function() {
+    // zoned time one day behind
+    var resultPDT = utcToZonedTime(
+      new Date('Sun Nov 1 2020 06:45:00 GMT-0000 (Greenwich Mean Time)'),
+      'America/Los_Angeles' // -7 hours
+    )
+
+    assert.equal(
+      format(resultPDT, "yyyy-MM-dd'T'HH:mm:ss.SSS"),
+      '2020-10-31T23:45:00.000'
+    )
+
+    // 15 mins before time switch
+    resultPDT = utcToZonedTime(
+      new Date('Sun Nov 1 2020 08:45:00 GMT-0000 (Greenwich Mean Time)'),
+      'America/Los_Angeles' // -7 hours
+    )
+
+    assert.equal(
+      format(resultPDT, "yyyy-MM-dd'T'HH:mm:ss.SSS"),
+      '2020-11-01T01:45:00.000'
+    )
+
+    // 15 mins after time switch
+    var resultPST = utcToZonedTime(
+      new Date('Sun Nov 1 2020 09:45:00 GMT-0000 (Greenwich Mean Time)'),
+      'America/Los_Angeles' // -8 hours
+    )
+
+    assert.equal(
+      format(resultPST, "yyyy-MM-dd'T'HH:mm:ss.SSS"),
+      '2020-11-01T01:45:00.000'
+    )
+  })
 })


### PR DESCRIPTION
Fixes an issue were the incorrect date and and therefore offset were being used when converting to local time during PDT -> PST switchover.

The first assertion in the test fails without the change in `src/utcToZonedTime/index.js`.

Not sure if this would have any other side effects, happy to include more tests to ensure.

This may also address the issue described in https://github.com/marnusw/date-fns-tz/issues/75.