### PR TITLE
Refine offset after initial calculation when timezone is provided

### DIFF
--- a/src/toDate/index.js
+++ b/src/toDate/index.js
@@ -156,7 +156,14 @@ export default function toDate(argument, dirtyOptions) {
     if (dateStrings.timezone || options.timeZone) {
       offset = tzParseTimezone(
         dateStrings.timezone || options.timeZone,
-        date
+        new Date(timestamp + time)
+      )
+      if (isNaN(offset)) {
+        return new Date(NaN)
+      }
+      offset = tzParseTimezone(
+        dateStrings.timezone || options.timeZone,
+        new Date(timestamp + time + offset)
       )
       if (isNaN(offset)) {
         return new Date(NaN)

--- a/src/toDate/test.js
+++ b/src/toDate/test.js
@@ -287,6 +287,56 @@ describe('toDate', function() {
             'Australia/Sydney',
             '2019-04-06T23:45:00',
             new Date('2019-04-06T12:45:00.000Z')
+          ],
+          [
+            'Australia/Sydney',
+            '2020-04-05T01:00:00',
+            new Date('2020-04-05T01:00:00+11:00')
+          ],
+          [
+            'Australia/Sydney',
+            '2020-04-05T02:00:00',
+            new Date('2020-04-05T02:00:00+10:00')
+          ],
+          [
+            'Australia/Sydney',
+            '2020-04-05T03:00:00',
+            new Date('2020-04-05T03:00:00+10:00')
+          ],
+          [
+            'Australia/Sydney',
+            '2020-10-04T01:00:00',
+            new Date('2020-10-04T01:00:00+10:00')
+          ],
+          [
+            'Australia/Sydney',
+            '2020-10-04T02:00:00',
+            new Date('2020-10-04T02:00:00+10:00')
+          ],
+          [
+            'Australia/Sydney',
+            '2020-10-04T03:00:00',
+            new Date('2020-10-04T03:00:00+11:00')
+          ],
+          [
+            'America/New_York',
+            '2020-03-08T01:00:00',
+            new Date('2020-03-08T01:00:00-05:00')
+          ],
+          [
+            'America/New_York',
+            '2020-03-08T03:00:00',
+            new Date('2020-03-08T03:00:00-04:00')
+          ],
+          [
+            'America/New_York',
+            '2020-11-01T01:00:00',
+            new Date('2020-11-01T01:00:00-04:00')
+          ],
+          [
+            'America/New_York',
+            '2020-11-01T03:00:00',
+            new Date('2020-11-01T03:00:00-05:00')
           ]
         ].forEach(([timeZone, dateStr, expectedDate]) => {
           assert.deepEqual(toDate(dateStr, { timeZone }), expectedDate)

--- a/src/toDate/test.js
+++ b/src/toDate/test.js
@@ -246,12 +246,51 @@ describe('toDate', function() {
         var result = toDate('2014-10-25T13:46:20 UTC')
         assert.deepEqual(result, new Date('2014-10-25T13:46:20Z'))
       })
-
-      it('uses the argument Date when determining offset', function() {
-        var result = toDate('2019-04-06T23:45:00', {
-          timeZone: 'Australia/Sydney'
+      it('produces correct offsets around a DST transition', function() {
+        ;[
+          [
+            'America/Vancouver',
+            '2020-11-01T01:00:00',
+            new Date('2020-11-01T01:00:00-07:00')
+          ],
+          [
+            'America/Vancouver',
+            '2020-11-01T02:00:00',
+            new Date('2020-11-01T02:00:00-08:00')
+          ],
+          [
+            'America/Vancouver',
+            '2020-11-01T03:00:00',
+            new Date('2020-11-01T03:00:00-08:00')
+          ],
+          [
+            'America/Vancouver',
+            '2020-11-01T23:00:00',
+            new Date('2020-11-01T23:00:00-08:00')
+          ],
+          [
+            'America/Vancouver',
+            '2021-03-14T01:00:00',
+            new Date('2021-03-14T01:00:00-08:00')
+          ],
+          [
+            'America/Vancouver',
+            '2021-03-14T02:00:00',
+            new Date('2021-03-14T02:00:00-07:00')
+          ],
+          [
+            'America/Vancouver',
+            '2021-03-14T03:00:00',
+            new Date('2021-03-14T03:00:00-07:00')
+          ],
+          [
+            'Australia/Sydney',
+            '2019-04-06T23:45:00',
+            new Date('2019-04-06T12:45:00.000Z')
+          ]
+        ].forEach(([timeZone, dateStr, expectedDate]) => {
+          assert.deepEqual(toDate(dateStr, { timeZone }), expectedDate)
         })
-        assert.deepEqual(result, new Date('2019-04-06T12:45:00.000Z'))
       })
     })
 


### PR DESCRIPTION
Fixes #85 (at least for me).

I believe that #46 came to the wrong conclusion, or at least one that privileges the eastern hemisphere over the west. Computing and then refining the offset (as is done for the non-timezone case) seems to do a better job of matching the offset to the hour, instead of the day (or the previous/next day!).

If @dcousens or anyone else has any more times that are giving them trouble, I think the more cases we can include in the test the merrier!