### PR TITLE
Add support for hyphen in timezone name

### DIFF
--- a/src/_lib/tzParseTimezone/index.js
+++ b/src/_lib/tzParseTimezone/index.js
@@ -8,7 +8,7 @@ var patterns = {
   timezoneZ: /^(Z)$/,
   timezoneHH: /^([+-])(\d{2})$/,
   timezoneHHMM: /^([+-])(\d{2}):?(\d{2})$/,
-  timezoneIANA: /(UTC|(?:[a-zA-Z]+\/[a-zA-Z_]+(?:\/[a-zA-Z_]+)?))$/,
+  timezoneIANA: /(UTC|(?:[a-zA-Z]+\/[a-zA-Z_-]+(?:\/[a-zA-Z_]+)?))$/,
 }
 
 // Parse various time zone offset formats to an offset in milliseconds

--- a/src/_lib/tzParseTimezone/test.js
+++ b/src/_lib/tzParseTimezone/test.js
@@ -29,6 +29,7 @@ describe('tzParseTimezone', function () {
     var date = new Date('2014-10-25T13:46:20Z')
     assert.equal(tzParseTimezone('America/New_York', date), 240 * 60 * 1000)
     assert.equal(tzParseTimezone('Europe/Paris', date), -120 * 60 * 1000)
+    assert.equal(tzParseTimezone('Asia/Ust-Nera', date), -660 * 60 * 1000)
   })
 
   describe('near DST changeover (AEST to AEDT)', function () {


### PR DESCRIPTION
When porting timezones from moment I noticed some inconsistencies between those two. Further investigation led me to discover that timezones which has hyphens as delimiter instead of underscore gives 0 offset. 
You can check current behavior in [sandbox](https://codesandbox.io/s/date-fns-tz-hyphen-bug-pubr4?file=/src/index.js). 
Currently there are three (I didn't counted etc zones like `Etc/GMT-1`) [canonical timezones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List) affected: 
- "America/Port-au-Prince", 
- "America/Blanc-Sablon" 
- "Asia/Ust-Nera"

The problem was in `timezoneIANA` regex, which didn't recognized timezone names with hyphen. 