### PR TITLE
Improve performance when validating the same timezones many times

### DIFF
--- a/src/_lib/tzParseTimezone/index.js
+++ b/src/_lib/tzParseTimezone/index.js
@@ -7,7 +7,7 @@ var patterns = {
   timezone: /([Z+-].*)$/,
   timezoneZ: /^(Z)$/,
   timezoneHH: /^([+-])(\d{2})$/,
-  timezoneHHMM: /^([+-])(\d{2}):?(\d{2})$/
+  timezoneHHMM: /^([+-])(\d{2}):?(\d{2})$/,
 }
 
 // Parse various time zone offset formats to an offset in milliseconds
@@ -125,11 +125,15 @@ function validateTimezone(hours, minutes) {
   return true
 }
 
+var validIANATimezoneCache = []
 function isValidTimezoneIANAString(timeZoneString) {
+  if (validIANATimezoneCache.indexOf(timeZoneString) >= 0) return true
+
   try {
-    Intl.DateTimeFormat(undefined, {timeZone: timeZoneString});
-    return true;
+    Intl.DateTimeFormat(undefined, { timeZone: timeZoneString })
+    validIANATimezoneCache.push(timeZoneString)
+    return true
   } catch (error) {
-    return false;
+    return false
   }
 }


### PR DESCRIPTION
Hello 👋 

Firstly thanks for this project, it's much needed.

When upgrading to the latest version we found a reduction in performance where we were using `utcToZonedTime()` on many dates.

It looks like the improvement to use `Intl.DateTimeFormat` (in https://github.com/marnusw/date-fns-tz/pull/129) for validating timezone strings came with a performance cost.

This PR looks to cache valid IANA timezones to improve performance when validating the same timezone many times.

For example, calling `tzParseTimezone` 100 times with the same `America/New_York` timezone, this PR takes it down from ~17-19ms back down to 3-4ms.

The other file changes look just from the linting being run on the file.

Thanks!