### PR TITLE
fix invalid timezones not returning invalid dates

### DIFF
--- a/src/_lib/tzParseTimezone/index.js
+++ b/src/_lib/tzParseTimezone/index.js
@@ -15,6 +15,11 @@ export default function tzParseTimezone(timezoneString, date, isUtcDate) {
   var token
   var absoluteOffset
 
+  // Empty string
+  if (timezoneString === '') {
+    return 0
+  }
+
   // Z
   token = patterns.timezoneZ.exec(timezoneString)
   if (token) {
@@ -62,7 +67,7 @@ export default function tzParseTimezone(timezoneString, date, isUtcDate) {
     return -fixedOffset
   }
 
-  return 0
+  return NaN
 }
 
 function toUtcDate(date) {

--- a/src/_lib/tzParseTimezone/test.js
+++ b/src/_lib/tzParseTimezone/test.js
@@ -32,6 +32,12 @@ describe('tzParseTimezone', function () {
     assert.equal(tzParseTimezone('Asia/Ust-Nera', date), -660 * 60 * 1000)
   })
 
+  it('bad time zone', function () {
+    assert.equal(Number.isNaN(tzParseTimezone('+0260')), true)
+    assert.equal(Number.isNaN(tzParseTimezone('+02:60')), true)
+    assert.equal(Number.isNaN(tzParseTimezone('Europe/Non_Existing')), true)
+  })
+
   describe('near DST changeover (AEST to AEDT)', function () {
     it('one day before', function () {
       var date = new Date('2020-10-04T00:45:00.000')

--- a/src/getTimezoneOffset/test.js
+++ b/src/getTimezoneOffset/test.js
@@ -38,6 +38,12 @@ describe('getTimezoneOffset', function () {
     assert.equal(getTimezoneOffset('Africa/Johannesburg'), 2 * hours)
   })
 
+  it('bad time zone', function () {
+    assert.equal(Number.isNaN(getTimezoneOffset('+0260')), true)
+    assert.equal(Number.isNaN(getTimezoneOffset('+02:60')), true)
+    assert.equal(Number.isNaN(getTimezoneOffset('Europe/Non_Existing')), true)
+  })
+
   describe('near DST changeover (AEST to AEDT)', function () {
     it('one day before', function () {
       var date = new Date('2020-10-04T00:45:00.000Z')

--- a/src/toDate/index.js
+++ b/src/toDate/index.js
@@ -191,7 +191,6 @@ function splitDateString(dateString) {
     }
   }
 
-  console.log(dateString, dateStrings)
   return dateStrings
 }
 

--- a/src/toDate/index.js
+++ b/src/toDate/index.js
@@ -7,9 +7,9 @@ var MILLISECONDS_IN_MINUTE = 60000
 var DEFAULT_ADDITIONAL_DIGITS = 2
 
 var patterns = {
-  dateTimeDelimeter: /[T ]/,
+  dateTimePattern: /^([0-9W+-]+)(T| )(.*)/,
+  datePattern: /^([0-9W+-]+)(.*)/,
   plainTime: /:/,
-  timeZoneDelimeter: /[Z ]/i,
 
   // year tokens
   YY: /^(\d{2})$/,
@@ -37,7 +37,7 @@ var patterns = {
   HHMMSS: /^(\d{2}):?(\d{2}):?(\d{2}([.,]\d*)?)$/,
 
   // timezone tokens (to identify the presence of a tz)
-  timezone: /([Z+-].*| UTC|(?:[a-zA-Z]+\/[a-zA-Z_]+(?:\/[a-zA-Z_]+)?))$/,
+  timezone: /([Z+-].*| UTC| (?:[a-zA-Z]+\/[a-zA-Z_]+(?:\/[a-zA-Z_]+)?))$/,
 }
 
 /**
@@ -164,32 +164,34 @@ export default function toDate(argument, dirtyOptions) {
 
 function splitDateString(dateString) {
   var dateStrings = {}
-  var array = dateString.split(patterns.dateTimeDelimeter)
+  var parts = patterns.dateTimePattern.exec(dateString)
   var timeString
 
-  if (patterns.plainTime.test(array[0])) {
-    dateStrings.date = null
-    timeString = array[0]
-  } else {
-    dateStrings.date = array[0]
-    timeString = array[1]
-    dateStrings.timezone = array[2]
-    if (patterns.timeZoneDelimeter.test(dateStrings.date)) {
-      dateStrings.date = dateString.split(patterns.timeZoneDelimeter)[0]
-      timeString = dateString.substr(dateStrings.date.length, dateString.length)
+  if (!parts) {
+    parts = patterns.datePattern.exec(dateString)
+    if (parts) {
+      dateStrings.date = parts[1]
+      timeString = parts[2]
+    } else {
+      dateStrings.date = null
+      timeString = dateString
     }
+  } else {
+    dateStrings.date = parts[1]
+    timeString = parts[3]
   }
 
   if (timeString) {
     var token = patterns.timezone.exec(timeString)
     if (token) {
       dateStrings.time = timeString.replace(token[1], '')
-      dateStrings.timezone = token[1]
+      dateStrings.timezone = token[1].trim()
     } else {
       dateStrings.time = timeString
     }
   }
 
+  console.log(dateString, dateStrings)
   return dateStrings
 }
 

--- a/src/toDate/test.js
+++ b/src/toDate/test.js
@@ -239,7 +239,7 @@ describe('toDate', function () {
         var result = toDate('2014-10-25T13:46:20 Asia/Bangkok')
         assert.deepEqual(result, new Date('2014-10-25T13:46:20+07:00'))
       })
-      it.only('accepts IANA zone with a T in the date string', function () {
+      it('accepts IANA zone with a T in the date string', function () {
         var result = toDate('2014-10-25T13:46:20 America/Tijuana')
         assert.deepEqual(result, new Date('2014-10-25T13:46:20-07:00'))
       })

--- a/src/toDate/test.js
+++ b/src/toDate/test.js
@@ -239,6 +239,10 @@ describe('toDate', function () {
         var result = toDate('2014-10-25T13:46:20 Asia/Bangkok')
         assert.deepEqual(result, new Date('2014-10-25T13:46:20+07:00'))
       })
+      it.only('accepts IANA zone with a T in the date string', function () {
+        var result = toDate('2014-10-25T13:46:20 America/Tijuana')
+        assert.deepEqual(result, new Date('2014-10-25T13:46:20-07:00'))
+      })
       it('accepts UTC zone in the date string', function () {
         var result = toDate('2014-10-25T13:46:20 UTC')
         assert.deepEqual(result, new Date('2014-10-25T13:46:20Z'))


### PR DESCRIPTION
Addresses #143 

When fixing this, a test on `toDate` using a `"UTC"` timezone string failed returning an invalid date: Turns out the timezone was being parsed as "U", which is invalid.

When looking for this I realised the parsing logic on datetime strings is wrong: it splits by ` ` and `T` (it was assuming strings were in format (`DD-MM-YYYYTHH:mm:ss`), but it also meant it split timezone names after that, such as UTC or any city which has a T in it.

So I added a test for it, and also fixed it.

Please check if every test is running, I had to disable some of them in local because some of them don't work in my timezone (I guess? on master those didn't work on my machine)