### PR TITLE
Add new to DateTimeFormat invocation

### DIFF
--- a/src/_lib/tzParseTimezone/index.js
+++ b/src/_lib/tzParseTimezone/index.js
@@ -137,7 +137,7 @@ var validIANATimezoneCache = {}
 function isValidTimezoneIANAString(timeZoneString) {
   if (validIANATimezoneCache[timeZoneString]) return true
   try {
-    Intl.DateTimeFormat(undefined, { timeZone: timeZoneString })
+    new Intl.DateTimeFormat(undefined, { timeZone: timeZoneString })
     validIANATimezoneCache[timeZoneString] = true
     return true
   } catch (error) {


### PR DESCRIPTION
In our project we mock `Intl.DateTimeFormat` in order to quickly run tests against various timezones. I understand [your preferred method](https://github.com/marnusw/date-fns-tz/issues/73#issuecomment-998946188) differs, but this had been working for us up to version `1.1.4` quite nicely.

In [1.1.5](https://github.com/marnusw/date-fns-tz/releases/tag/v1.1.5) a [commit](https://github.com/marnusw/date-fns-tz/commit/3a72f7e82cfb1ff2af085c2e4963795faaf562bf) introduced `isValidTimezoneIANAString` which invokes `Intl.DateTimeFormat` **without** `new`. When mocking, this causes the error `Uncaught TypeError: Class constructor DateTimeFormatFake cannot be invoked without 'new'` which subsequently causes an `Invalid Date` error. The fix is as simple as adding `new`, which shouldn't affect anyone who isn't mocking, but may help those who would like to.