### PR TITLE
fix: update format types to match date-fns

### DIFF
--- a/src/format/index.js
+++ b/src/format/index.js
@@ -272,7 +272,7 @@ var tzFormattingTokensRegExp = /([xXOz]+)|''|'(''|[^'])+('|$)/g
  *
  * - Characters are now escaped using single quote symbols (`'`) instead of square brackets.
  *
- * @param {Date|String|Number} date - the original date
+ * @param {Date|Number} date - the original date
  * @param {String} format - the string of tokens
  * @param {OptionsWithTZ} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {0|1|2} [options.additionalDigits=2] - passed to `toDate`. See [toDate]{@link

--- a/src/format/index.js.flow
+++ b/src/format/index.js.flow
@@ -16,8 +16,4 @@ type OptionsWithTZ = {
   awareOfUnicodeTokens?: boolean,
 }
 
-declare module.exports: (
-  date: Date | string | number,
-  format: string,
-  options?: OptionsWithTZ
-) => string
+declare module.exports: (date: Date | number, format: string, options?: OptionsWithTZ) => string

--- a/src/fp/format/index.js.flow
+++ b/src/fp/format/index.js.flow
@@ -20,4 +20,4 @@ type CurriedFn1<A, R> = <A>(a: A) => R
 
 type CurriedFn2<A, B, R> = <A>(a: A) => CurriedFn1<B, R> | (<A, B>(a: A, b: B) => R)
 
-declare module.exports: CurriedFn2<string, Date | string | number, string>
+declare module.exports: CurriedFn2<string, Date | number, string>

--- a/src/fp/formatWithOptions/index.js.flow
+++ b/src/fp/formatWithOptions/index.js.flow
@@ -26,4 +26,4 @@ type CurriedFn3<A, B, C, R> = <A>(
   | CurriedFn2<B, C, R>
   | (<A, B>(a: A, b: B) => CurriedFn1<C, R> | (<A, B, C>(a: A, b: B, c: C) => R))
 
-declare module.exports: CurriedFn3<OptionsWithTZ, string, Date | string | number, string>
+declare module.exports: CurriedFn3<OptionsWithTZ, string, Date | number, string>

--- a/src/fp/index.js.flow
+++ b/src/fp/index.js.flow
@@ -42,7 +42,7 @@ type CurriedFn4<A, B, C, D, R> = <A>(
         ) => CurriedFn1<D, R> | (<A, B, C, D>(a: A, b: B, c: C, d: D) => R)))
 
 declare module.exports: {
-  format: CurriedFn2<string, Date | string | number, string>,
+  format: CurriedFn2<string, Date | number, string>,
   formatInTimeZone: CurriedFn3<string, string, Date | string | number, string>,
   formatInTimeZoneWithOptions: CurriedFn4<
     OptionsWithTZ,
@@ -51,7 +51,7 @@ declare module.exports: {
     Date | string | number,
     string
   >,
-  formatWithOptions: CurriedFn3<OptionsWithTZ, string, Date | string | number, string>,
+  formatWithOptions: CurriedFn3<OptionsWithTZ, string, Date | number, string>,
   getTimezoneOffset: CurriedFn2<Date | number, string, number>,
   toDate: CurriedFn1<Date | string | number, Date>,
   toDateWithOptions: CurriedFn2<OptionsWithTZ, Date | string | number, Date>,

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -17,7 +17,7 @@ type OptionsWithTZ = {
 }
 
 declare module.exports: {
-  format: (date: Date | string | number, format: string, options?: OptionsWithTZ) => string,
+  format: (date: Date | number, format: string, options?: OptionsWithTZ) => string,
 
   formatInTimeZone: (
     date: Date | string | number,

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -46,7 +46,7 @@ declare module 'date-fns-tz' {
 declare module 'date-fns-tz' {
   import { OptionsWithTZ } from 'date-fns-tz'
 
-  function format(date: Date | string | number, format: string, options?: OptionsWithTZ): string
+  function format(date: Date | number, format: string, options?: OptionsWithTZ): string
   namespace format {}
 
   function formatInTimeZone(
@@ -173,7 +173,7 @@ declare module 'date-fns-tz/zonedTimeToUtc/index.js' {
 declare module 'date-fns-tz/fp' {
   import { OptionsWithTZ } from 'date-fns-tz'
 
-  const format: CurriedFn2<string, Date | string | number, string>
+  const format: CurriedFn2<string, Date | number, string>
   namespace format {}
 
   const formatInTimeZone: CurriedFn3<string, string, Date | string | number, string>
@@ -188,7 +188,7 @@ declare module 'date-fns-tz/fp' {
   >
   namespace formatInTimeZoneWithOptions {}
 
-  const formatWithOptions: CurriedFn3<OptionsWithTZ, string, Date | string | number, string>
+  const formatWithOptions: CurriedFn3<OptionsWithTZ, string, Date | number, string>
   namespace formatWithOptions {}
 
   const getTimezoneOffset: CurriedFn2<Date | number, string, number>
@@ -383,7 +383,7 @@ declare module 'date-fns-tz/fp/zonedTimeToUtcWithOptions/index.js' {
 declare module 'date-fns-tz/esm' {
   import { OptionsWithTZ } from 'date-fns-tz'
 
-  function format(date: Date | string | number, format: string, options?: OptionsWithTZ): string
+  function format(date: Date | number, format: string, options?: OptionsWithTZ): string
   namespace format {}
 
   function formatInTimeZone(
@@ -510,7 +510,7 @@ declare module 'date-fns-tz/esm/zonedTimeToUtc/index.js' {
 declare module 'date-fns-tz/esm/fp' {
   import { OptionsWithTZ } from 'date-fns-tz'
 
-  const format: CurriedFn2<string, Date | string | number, string>
+  const format: CurriedFn2<string, Date | number, string>
   namespace format {}
 
   const formatInTimeZone: CurriedFn3<string, string, Date | string | number, string>
@@ -525,7 +525,7 @@ declare module 'date-fns-tz/esm/fp' {
   >
   namespace formatInTimeZoneWithOptions {}
 
-  const formatWithOptions: CurriedFn3<OptionsWithTZ, string, Date | string | number, string>
+  const formatWithOptions: CurriedFn3<OptionsWithTZ, string, Date | number, string>
   namespace formatWithOptions {}
 
   const getTimezoneOffset: CurriedFn2<Date | number, string, number>


### PR DESCRIPTION
Fixes #198 

Updates the types for `format` from `date-fns` to accept `Date | Number` and removes string.