### PR TITLE
Optimize configuration for ESM exports (entry points for cjs / esm / typescript)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,9 @@ If you find this library useful, why not
 
 ## ESM and CommonJS
 
-As of `v1.3.0` this library supports native ESM imports in Node.js. It is important to
-use the proper import path for your use case. Set the `type` property in your project's
-`package.json` to either `module`, for ESM, or `commonjs` and
-
-- For **ESM** import from `date-fns-tz/esm` or its sub-paths
-- For **CommonJS** import from `date-fns-tz` or its sub-paths
+As of `v1.3.0` this library supports native ESM imports in Node.js. Since exports field in [package.json](./package.json)
+defines the correct entry point depending on project type (`commonjs` vs. `ESM`) the import path does not change.
+Make sure to set the `type` property in your project's `package.json` to either `module`, for ESM, or `commonjs` and
 
 Even when using ESM some CommonJS imports from `date-fns` will be used until they support
 ESM natively as well [date-fns#1781](https://github.com/date-fns/date-fns/issues/1781).

--- a/package.json
+++ b/package.json
@@ -24,35 +24,77 @@
   "module": "esm/index.js",
   "types": "typings.d.ts",
   "exports": {
-    ".": "./index.js",
     "./package.json": "./package.json",
-    "./format": "./format/index.js",
-    "./formatInTimeZone": "./formatInTimeZone/index.js",
-    "./getTimezoneOffset": "./getTimezoneOffset/index.js",
-    "./toDate": "./toDate/index.js",
-    "./utcToZonedTime": "./utcToZonedTime/index.js",
-    "./zonedTimeToUtc": "./zonedTimeToUtc/index.js",
-    "./fp": "./fp/index.js",
-    "./fp/format": "./fp/format/index.js",
-    "./fp/formatInTimeZone": "./fp/formatInTimeZone/index.js",
-    "./fp/getTimezoneOffset": "./fp/getTimezoneOffset/index.js",
-    "./fp/toDate": "./fp/toDate/index.js",
-    "./fp/utcToZonedTime": "./fp/utcToZonedTime/index.js",
-    "./fp/zonedTimeToUtc": "./fp/zonedTimeToUtc/index.js",
-    "./esm": "./esm/index.js",
-    "./esm/format": "./esm/format/index.js",
-    "./esm/formatInTimeZone": "./esm/formatInTimeZone/index.js",
-    "./esm/getTimezoneOffset": "./esm/getTimezoneOffset/index.js",
-    "./esm/toDate": "./esm/toDate/index.js",
-    "./esm/utcToZonedTime": "./esm/utcToZonedTime/index.js",
-    "./esm/zonedTimeToUtc": "./esm/zonedTimeToUtc/index.js",
-    "./esm/fp": "./esm/fp/index.js",
-    "./esm/fp/format": "./esm/fp/format/index.js",
-    "./esm/fp/formatInTimeZone": "./esm/fp/formatInTimeZone/index.js",
-    "./esm/fp/getTimezoneOffset": "./esm/fp/getTimezoneOffset/index.js",
-    "./esm/fp/toDate": "./esm/fp/toDate/index.js",
-    "./esm/fp/utcToZonedTime": "./esm/fp/utcToZonedTime/index.js",
-    "./esm/fp/zonedTimeToUtc": "./esm/fp/zonedTimeToUtc/index.js"
+    ".": {
+      "require": "./index.js",
+      "import": "./esm/index.js",
+      "types": "./typings.d.ts"
+    },
+    "./format": {
+      "types": "./format/index.d.ts",
+      "require": "./format/index.js",
+      "import": "./esm/format/index.js"
+    },
+    "./formatInTimeZone": {
+      "types": "./formatInTimeZone/index.d.ts",
+      "require": "./formatInTimeZone/index.js",
+      "import": "./esm/formatInTimeZone/index.js"
+    },
+    "./getTimezoneOffset": {
+      "types": "./getTimezoneOffset/index.d.ts",
+      "require": "./getTimezoneOffset/index.js",
+      "import": "./esm/getTimezoneOffset/index.js"
+    },
+    "./toDate": {
+      "types": "./toDate/index.d.ts",
+      "require": "./toDate/index.js",
+      "import": "./esm/toDate/index.js"
+    },
+    "./utcToZonedTime": {
+      "types": "./utcToZonedTime/index.d.ts",
+      "require": "./utcToZonedTime/index.js",
+      "import": "./esm/utcToZonedTime/index.js"
+    },
+    "./zonedTimeToUtc": {
+      "types": "./zonedTimeToUtc/index.d.ts",
+      "require": "./zonedTimeToUtc/index.js",
+      "import": "./esm/zonedTimeToUtc/index.js"
+    },
+    "./fp": {
+      "types": "./fp/index.d.ts",
+      "require": "./fp/index.js",
+      "import": "./esm/fp/index.js"
+    },
+    "./fp/format": {
+      "types": "./fp/format/index.d.ts",
+      "require": "./fp/format/index.js",
+      "import": "./esm/fp/format/index.js"
+    },
+    "./fp/formatInTimeZone": {
+      "types": "./fp/formatInTimeZone/index.d.ts",
+      "require": "./fp/formatInTimeZone/index.js",
+      "import": "./esm/fp/formatInTimeZone/index.js"
+    },
+    "./fp/getTimezoneOffset": {
+      "types": "./fp/getTimezoneOffset/index.d.ts",
+      "require": "./fp/getTimezoneOffset/index.js",
+      "import": "./esm/fp/getTimezoneOffset/index.js"
+    },
+    "./fp/toDate": {
+      "types": "./fp/toDate/index.d.ts",
+      "require": "./fp/toDate/index.js",
+      "import": "./esm/fp/toDate/index.js"
+    },
+    "./fp/utcToZonedTime": {
+      "types": "./fp/utcToZonedTime/index.d.ts",
+      "require": "./fp/utcToZonedTime/index.js",
+      "import": "./esm/fp/utcToZonedTime/index.js"
+    },
+    "./fp/zonedTimeToUtc": {
+      "types": "./fp/zonedTimeToUtc/index.d.ts",
+      "require": "./fp/zonedTimeToUtc/index.js",
+      "import": "./esm/fp/zonedTimeToUtc/index.js"
+    }
   },
   "scripts": {
     "build": "./scripts/build/build.sh",

--- a/package.json
+++ b/package.json
@@ -26,74 +26,74 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "require": "./index.js",
+      "types": "./typings.d.ts",
       "import": "./esm/index.js",
-      "types": "./typings.d.ts"
+      "require": "./index.js"
     },
     "./format": {
       "types": "./format/index.d.ts",
-      "require": "./format/index.js",
-      "import": "./esm/format/index.js"
+      "import": "./esm/format/index.js",
+      "require": "./format/index.js"
     },
     "./formatInTimeZone": {
       "types": "./formatInTimeZone/index.d.ts",
-      "require": "./formatInTimeZone/index.js",
-      "import": "./esm/formatInTimeZone/index.js"
+      "import": "./esm/formatInTimeZone/index.js",
+      "require": "./formatInTimeZone/index.js"
     },
     "./getTimezoneOffset": {
       "types": "./getTimezoneOffset/index.d.ts",
-      "require": "./getTimezoneOffset/index.js",
-      "import": "./esm/getTimezoneOffset/index.js"
+      "import": "./esm/getTimezoneOffset/index.js",
+      "require": "./getTimezoneOffset/index.js"
     },
     "./toDate": {
       "types": "./toDate/index.d.ts",
-      "require": "./toDate/index.js",
-      "import": "./esm/toDate/index.js"
+      "import": "./esm/toDate/index.js",
+      "require": "./toDate/index.js"
     },
     "./utcToZonedTime": {
       "types": "./utcToZonedTime/index.d.ts",
-      "require": "./utcToZonedTime/index.js",
-      "import": "./esm/utcToZonedTime/index.js"
+      "import": "./esm/utcToZonedTime/index.js",
+      "require": "./utcToZonedTime/index.js"
     },
     "./zonedTimeToUtc": {
       "types": "./zonedTimeToUtc/index.d.ts",
-      "require": "./zonedTimeToUtc/index.js",
-      "import": "./esm/zonedTimeToUtc/index.js"
+      "import": "./esm/zonedTimeToUtc/index.js",
+      "require": "./zonedTimeToUtc/index.js"
     },
     "./fp": {
       "types": "./fp/index.d.ts",
-      "require": "./fp/index.js",
-      "import": "./esm/fp/index.js"
+      "import": "./esm/fp/index.js",
+      "require": "./fp/index.js"
     },
     "./fp/format": {
       "types": "./fp/format/index.d.ts",
-      "require": "./fp/format/index.js",
-      "import": "./esm/fp/format/index.js"
+      "import": "./esm/fp/format/index.js",
+      "require": "./fp/format/index.js"
     },
     "./fp/formatInTimeZone": {
       "types": "./fp/formatInTimeZone/index.d.ts",
-      "require": "./fp/formatInTimeZone/index.js",
-      "import": "./esm/fp/formatInTimeZone/index.js"
+      "import": "./esm/fp/formatInTimeZone/index.js",
+      "require": "./fp/formatInTimeZone/index.js"
     },
     "./fp/getTimezoneOffset": {
       "types": "./fp/getTimezoneOffset/index.d.ts",
-      "require": "./fp/getTimezoneOffset/index.js",
-      "import": "./esm/fp/getTimezoneOffset/index.js"
+      "import": "./esm/fp/getTimezoneOffset/index.js",
+      "require": "./fp/getTimezoneOffset/index.js"
     },
     "./fp/toDate": {
       "types": "./fp/toDate/index.d.ts",
-      "require": "./fp/toDate/index.js",
-      "import": "./esm/fp/toDate/index.js"
+      "import": "./esm/fp/toDate/index.js",
+      "require": "./fp/toDate/index.js"
     },
     "./fp/utcToZonedTime": {
       "types": "./fp/utcToZonedTime/index.d.ts",
-      "require": "./fp/utcToZonedTime/index.js",
-      "import": "./esm/fp/utcToZonedTime/index.js"
+      "import": "./esm/fp/utcToZonedTime/index.js",
+      "require": "./fp/utcToZonedTime/index.js"
     },
     "./fp/zonedTimeToUtc": {
       "types": "./fp/zonedTimeToUtc/index.d.ts",
-      "require": "./fp/zonedTimeToUtc/index.js",
-      "import": "./esm/fp/zonedTimeToUtc/index.js"
+      "import": "./esm/fp/zonedTimeToUtc/index.js",
+      "require": "./fp/zonedTimeToUtc/index.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
Optimise configuration for ESM exports (entry points for `cjs`: require / `esm`: import and also `typescript`: types)

**BREAKING CHANGE**: Imports from esm subpaths must be replaced by the non-esm path, since the runtime will pick the correct entry point depending on `package.json#type` property (`commonjs` vs. `module`).

Before: `import {} from 'date-fns-tz/esm/format'` -> after: `import {} form 'date-fns-tz/format'`

This superseeds the existing PR (#211 ) with additional configuration for `types` field.

---

Motivation: I was not able to use `date-fns-tz` with `esm` and `jest` without this patch being applied.