### PR TITLE
Fix tzParseTimezone to parse 00:30 timezones properly

### DIFF
--- a/src/_lib/tzParseTimezone/index.js
+++ b/src/_lib/tzParseTimezone/index.js
@@ -8,7 +8,7 @@ var patterns = {
   timezone: /([Z+-].*)$/,
   timezoneZ: /^(Z)$/,
   timezoneHH: /^([+-]\d{2})$/,
-  timezoneHHMM: /^([+-]\d{2}):?(\d{2})$/,
+  timezoneHHMM: /^([+-])(\d{2}):?(\d{2})$/,
 }
 
 // Parse various time zone offset formats to an offset in milliseconds
@@ -44,15 +44,15 @@ export default function tzParseTimezone(timezoneString, date, isUtcDate) {
   // ±hh:mm or ±hhmm
   token = patterns.timezoneHHMM.exec(timezoneString)
   if (token) {
-    hours = parseInt(token[1], 10)
-    var minutes = parseInt(token[2], 10)
+    hours = parseInt(token[2], 10)
+    var minutes = parseInt(token[3], 10)
 
     if (!validateTimezone(hours, minutes)) {
       return NaN
     }
 
     absoluteOffset = Math.abs(hours) * MILLISECONDS_IN_HOUR + minutes * MILLISECONDS_IN_MINUTE
-    return hours > 0 ? -absoluteOffset : absoluteOffset
+    return token[1] === '+' ? -absoluteOffset : absoluteOffset
   }
 
   // IANA time zone

--- a/src/_lib/tzParseTimezone/test.js
+++ b/src/_lib/tzParseTimezone/test.js
@@ -20,7 +20,9 @@ describe('tzParseTimezone', function () {
 
   it('±hhmm time zone format', function () {
     assert.equal(tzParseTimezone('-0430'), 270 * 60 * 1000)
+    assert.equal(tzParseTimezone('-0030'), 30 * 60 * 1000)
     assert.equal(tzParseTimezone('+0230'), -150 * 60 * 1000)
+    assert.equal(tzParseTimezone('+0030'), -30 * 60 * 1000)
   })
 
   it('±hh:mm time zone format', function () {
@@ -28,10 +30,12 @@ describe('tzParseTimezone', function () {
     assert.equal(tzParseTimezone('-12:00'), 720 * 60 * 1000)
     assert.equal(tzParseTimezone('-11:30'), 690 * 60 * 1000)
     assert.equal(tzParseTimezone('-05:00'), 300 * 60 * 1000)
+    assert.equal(tzParseTimezone('-00:30'), 30 * 60 * 1000)
     assert.equal(tzParseTimezone('+03:00'), -180 * 60 * 1000)
     assert.equal(tzParseTimezone('+11:30'), -690 * 60 * 1000)
     assert.equal(tzParseTimezone('+12:00'), -720 * 60 * 1000)
     assert.equal(tzParseTimezone('+23:59'), -1439 * 60 * 1000)
+    assert.equal(tzParseTimezone('+00:30'), -30 * 60 * 1000)
   })
 
   it('IANA time zone', function () {


### PR DESCRIPTION
This PR fixes the issue that `tzParseTimezone` interprets '+00:30' as '-00:30' and vise versa.