### PR TITLE
fix: samsung internet does not include leading zero for 'numeric' format

### DIFF
--- a/src/_lib/tzTokenizeDate/index.js
+++ b/src/_lib/tzTokenizeDate/index.js
@@ -63,6 +63,7 @@ function getDateTimeFormat(timeZone) {
     }).format(new Date('2014-06-25T04:00:00.123Z'))
     var hourCycleSupported =
       testDateFormatted === '06/25/2014, 00:00:00' ||
+      testDateFormatted === '6/25/2014, 00:00:00' || // Samsung Internet does not include leading zero for 'numeric' month format.
       testDateFormatted === '‎06‎/‎25‎/‎2014‎ ‎00‎:‎00‎:‎00'
 
     dtfCache[timeZone] = hourCycleSupported


### PR DESCRIPTION
Without this fix, Samsung Internet browser will format all dates as AM because its using the wrong path for hourCycleSupported. It IS supported, but the detection is wrong because Samsung Internet does not include leading zeroes for the month format.

This fixes a regression introduced by f7806f37e1a131314ec348d7e5c886f6ba1c8daa.