### PR TITLE
Improving correctness of the `formatInTimeZone` close to the DST threshold

### DIFF
--- a/docs/OptionsWithTZ.js
+++ b/docs/OptionsWithTZ.js
@@ -19,6 +19,8 @@
  *   See [toDate]{@link https://date-fns.org/docs/toDate}
  * @property {String} [timeZone=''] - used to specify the IANA time zone offset of a date String.
  *   Used by all functions that take String as Date-like argument.
+ * @property {Date|Number} [originalDate] - used to pick the correct IANA time zone of a date.
+ *   Used by `format` function.
  * @property {Locale} [locale=defaultLocale] - the locale object.
  *   Used by `formatDistance`, `formatDistanceStrict`, `format` and `parse`.
  *   See [Locale]{@link https://date-fns.org/docs/Locale}

--- a/src/format/index.js
+++ b/src/format/index.js
@@ -286,6 +286,7 @@ var tzFormattingTokensRegExp = /([xXOz]+)|''|'(''|[^'])+('|$)/g
  *   - Some of the local week-numbering year tokens (`YY`, `YYYY`) that are confused with the calendar year tokens
  *   (`yy`, `yyyy`). See: https://git.io/fxCyr
  * @param {String} [options.timeZone=''] - used to specify the IANA time zone offset of a date String.
+ * @param {Date|Number} [options.originalDate] - used to pick the correct IANA time zone of a date.
  * @returns {String} the formatted date string
  * @throws {TypeError} 2 arguments required
  * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
@@ -320,7 +321,7 @@ export default function format(dirtyDate, dirtyFormatStr, dirtyOptions) {
 
   var matches = formatStr.match(tzFormattingTokensRegExp)
   if (matches) {
-    var date = toDate(dirtyDate, options)
+    var date = toDate(options.originalDate || dirtyDate, options)
     // Work through each match and replace the tz token in the format string with the quoted
     // formatted time zone so the remaining tokens can be filled in by date-fns#format.
     formatStr = matches.reduce(function (result, token) {

--- a/src/format/index.js.flow
+++ b/src/format/index.js.flow
@@ -8,6 +8,7 @@ type OptionsWithTZ = {
   firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7,
   additionalDigits?: 0 | 1 | 2,
   timeZone?: string,
+  originalDate?: Date | number,
   locale?: Locale,
   includeSeconds?: boolean,
   addSuffix?: boolean,

--- a/src/format/test.js
+++ b/src/format/test.js
@@ -101,7 +101,7 @@ describe('format', function () {
     assert(format(date, "''h 'o''clock'''") === "'5 o'clock'")
   })
 
-  it('accepts new line charactor', function () {
+  it('accepts new line character', function () {
     var date = new Date(2014, 3, 4, 5)
     assert.equal(format(date, "yyyy-MM-dd'\n'HH:mm:ss"), '2014-04-04\n05:00:00')
   })

--- a/src/formatInTimeZone/index.js
+++ b/src/formatInTimeZone/index.js
@@ -27,5 +27,6 @@ import utcToZonedTime from '../utcToZonedTime/index.js'
 export default function formatInTimeZone(date, timeZone, formatStr, options) {
   var extendedOptions = cloneObject(options)
   extendedOptions.timeZone = timeZone
+  extendedOptions.originalDate = date
   return format(utcToZonedTime(date, timeZone), formatStr, extendedOptions)
 }

--- a/src/formatInTimeZone/index.js.flow
+++ b/src/formatInTimeZone/index.js.flow
@@ -8,6 +8,7 @@ type OptionsWithTZ = {
   firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7,
   additionalDigits?: 0 | 1 | 2,
   timeZone?: string,
+  originalDate?: Date | number,
   locale?: Locale,
   includeSeconds?: boolean,
   addSuffix?: boolean,

--- a/src/formatInTimeZone/test.js
+++ b/src/formatInTimeZone/test.js
@@ -1,4 +1,5 @@
 import assert from 'power-assert'
+import enGB from 'date-fns/locale/en-GB'
 import formatInTimeZone from './index'
 
 describe('formatInTimeZone', function () {
@@ -40,6 +41,62 @@ describe('formatInTimeZone', function () {
       it(`format type: ${test.formatType}, time zone type: ${test.timeZoneType}`, function () {
         assert(formatInTimeZone(date, test.timeZone, test.format) === test.expected)
       })
+    })
+  })
+
+  describe('populates the timezone name and offset correctly close to DST threshold', function () {
+    it('during summer time: CEST', function () {
+      var date = new Date('2021-08-01T00:30:00Z')
+      var timeZone = 'Europe/Paris'
+      var format = 'z XXX'
+      var expected = 'CEST +02:00'
+      var options = { locale: enGB }
+      assert(formatInTimeZone(date, timeZone, format, options) === expected)
+    })
+
+    it('during winter time: CET', function () {
+      var date = '2021-01-01T01:30:00Z'
+      var timeZone = 'Europe/Paris'
+      var format = 'z XXX'
+      var expected = 'CET +01:00'
+      var options = { locale: enGB }
+      assert(formatInTimeZone(date, timeZone, format, options) === expected)
+    })
+
+    it('before DST changeover: (CEST to CET)', function () {
+      var date = '2021-10-31T00:30:00Z'
+      var timeZone = 'Europe/Paris'
+      var format = 'z XXX'
+      var expected = 'CEST +02:00'
+      var options = { locale: enGB }
+      assert(formatInTimeZone(date, timeZone, format, options) === expected)
+    })
+
+    it('after DST changeover: (CEST to CET)', function () {
+      var date = '2021-10-31T01:30:00Z'
+      var timeZone = 'Europe/Paris'
+      var format = 'z XXX'
+      var expected = 'CET +01:00'
+      var options = { locale: enGB }
+      assert(formatInTimeZone(date, timeZone, format, options) === expected)
+    })
+
+    it('before DST changeover: (CET to CEST)', function () {
+      var date = '2021-03-28T00:30:00Z'
+      var timeZone = 'Europe/Paris'
+      var format = 'z XXX'
+      var expected = 'CET +01:00'
+      var options = { locale: enGB }
+      assert(formatInTimeZone(date, timeZone, format, options) === expected)
+    })
+
+    it('after DST changeover: (CET to CEST)', function () {
+      var date = '2021-03-28T01:30:00Z'
+      var timeZone = 'Europe/Paris'
+      var format = 'z XXX'
+      var expected = 'CEST +02:00'
+      var options = { locale: enGB }
+      assert(formatInTimeZone(date, timeZone, format, options) === expected)
     })
   })
 

--- a/src/fp/format/index.js.flow
+++ b/src/fp/format/index.js.flow
@@ -8,6 +8,7 @@ type OptionsWithTZ = {
   firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7,
   additionalDigits?: 0 | 1 | 2,
   timeZone?: string,
+  originalDate?: Date | number,
   locale?: Locale,
   includeSeconds?: boolean,
   addSuffix?: boolean,

--- a/src/fp/formatInTimeZone/index.js.flow
+++ b/src/fp/formatInTimeZone/index.js.flow
@@ -8,6 +8,7 @@ type OptionsWithTZ = {
   firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7,
   additionalDigits?: 0 | 1 | 2,
   timeZone?: string,
+  originalDate?: Date | number,
   locale?: Locale,
   includeSeconds?: boolean,
   addSuffix?: boolean,

--- a/src/fp/formatInTimeZoneWithOptions/index.js.flow
+++ b/src/fp/formatInTimeZoneWithOptions/index.js.flow
@@ -8,6 +8,7 @@ type OptionsWithTZ = {
   firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7,
   additionalDigits?: 0 | 1 | 2,
   timeZone?: string,
+  originalDate?: Date | number,
   locale?: Locale,
   includeSeconds?: boolean,
   addSuffix?: boolean,

--- a/src/fp/formatWithOptions/index.js.flow
+++ b/src/fp/formatWithOptions/index.js.flow
@@ -8,6 +8,7 @@ type OptionsWithTZ = {
   firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7,
   additionalDigits?: 0 | 1 | 2,
   timeZone?: string,
+  originalDate?: Date | number,
   locale?: Locale,
   includeSeconds?: boolean,
   addSuffix?: boolean,

--- a/src/fp/getTimezoneOffset/index.js.flow
+++ b/src/fp/getTimezoneOffset/index.js.flow
@@ -8,6 +8,7 @@ type OptionsWithTZ = {
   firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7,
   additionalDigits?: 0 | 1 | 2,
   timeZone?: string,
+  originalDate?: Date | number,
   locale?: Locale,
   includeSeconds?: boolean,
   addSuffix?: boolean,

--- a/src/fp/index.js.flow
+++ b/src/fp/index.js.flow
@@ -8,6 +8,7 @@ type OptionsWithTZ = {
   firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7,
   additionalDigits?: 0 | 1 | 2,
   timeZone?: string,
+  originalDate?: Date | number,
   locale?: Locale,
   includeSeconds?: boolean,
   addSuffix?: boolean,

--- a/src/fp/toDate/index.js.flow
+++ b/src/fp/toDate/index.js.flow
@@ -8,6 +8,7 @@ type OptionsWithTZ = {
   firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7,
   additionalDigits?: 0 | 1 | 2,
   timeZone?: string,
+  originalDate?: Date | number,
   locale?: Locale,
   includeSeconds?: boolean,
   addSuffix?: boolean,

--- a/src/fp/toDateWithOptions/index.js.flow
+++ b/src/fp/toDateWithOptions/index.js.flow
@@ -8,6 +8,7 @@ type OptionsWithTZ = {
   firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7,
   additionalDigits?: 0 | 1 | 2,
   timeZone?: string,
+  originalDate?: Date | number,
   locale?: Locale,
   includeSeconds?: boolean,
   addSuffix?: boolean,

--- a/src/fp/utcToZonedTime/index.js.flow
+++ b/src/fp/utcToZonedTime/index.js.flow
@@ -8,6 +8,7 @@ type OptionsWithTZ = {
   firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7,
   additionalDigits?: 0 | 1 | 2,
   timeZone?: string,
+  originalDate?: Date | number,
   locale?: Locale,
   includeSeconds?: boolean,
   addSuffix?: boolean,

--- a/src/fp/utcToZonedTimeWithOptions/index.js.flow
+++ b/src/fp/utcToZonedTimeWithOptions/index.js.flow
@@ -8,6 +8,7 @@ type OptionsWithTZ = {
   firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7,
   additionalDigits?: 0 | 1 | 2,
   timeZone?: string,
+  originalDate?: Date | number,
   locale?: Locale,
   includeSeconds?: boolean,
   addSuffix?: boolean,

--- a/src/fp/zonedTimeToUtc/index.js.flow
+++ b/src/fp/zonedTimeToUtc/index.js.flow
@@ -8,6 +8,7 @@ type OptionsWithTZ = {
   firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7,
   additionalDigits?: 0 | 1 | 2,
   timeZone?: string,
+  originalDate?: Date | number,
   locale?: Locale,
   includeSeconds?: boolean,
   addSuffix?: boolean,

--- a/src/fp/zonedTimeToUtcWithOptions/index.js.flow
+++ b/src/fp/zonedTimeToUtcWithOptions/index.js.flow
@@ -8,6 +8,7 @@ type OptionsWithTZ = {
   firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7,
   additionalDigits?: 0 | 1 | 2,
   timeZone?: string,
+  originalDate?: Date | number,
   locale?: Locale,
   includeSeconds?: boolean,
   addSuffix?: boolean,

--- a/src/getTimezoneOffset/index.js.flow
+++ b/src/getTimezoneOffset/index.js.flow
@@ -8,6 +8,7 @@ type OptionsWithTZ = {
   firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7,
   additionalDigits?: 0 | 1 | 2,
   timeZone?: string,
+  originalDate?: Date | number,
   locale?: Locale,
   includeSeconds?: boolean,
   addSuffix?: boolean,

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -8,6 +8,7 @@ type OptionsWithTZ = {
   firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7,
   additionalDigits?: 0 | 1 | 2,
   timeZone?: string,
+  originalDate?: Date | number,
   locale?: Locale,
   includeSeconds?: boolean,
   addSuffix?: boolean,

--- a/src/toDate/index.js.flow
+++ b/src/toDate/index.js.flow
@@ -8,6 +8,7 @@ type OptionsWithTZ = {
   firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7,
   additionalDigits?: 0 | 1 | 2,
   timeZone?: string,
+  originalDate?: Date | number,
   locale?: Locale,
   includeSeconds?: boolean,
   addSuffix?: boolean,

--- a/src/utcToZonedTime/index.js.flow
+++ b/src/utcToZonedTime/index.js.flow
@@ -8,6 +8,7 @@ type OptionsWithTZ = {
   firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7,
   additionalDigits?: 0 | 1 | 2,
   timeZone?: string,
+  originalDate?: Date | number,
   locale?: Locale,
   includeSeconds?: boolean,
   addSuffix?: boolean,

--- a/src/zonedTimeToUtc/index.js.flow
+++ b/src/zonedTimeToUtc/index.js.flow
@@ -8,6 +8,7 @@ type OptionsWithTZ = {
   firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7,
   additionalDigits?: 0 | 1 | 2,
   timeZone?: string,
+  originalDate?: Date | number,
   locale?: Locale,
   includeSeconds?: boolean,
   addSuffix?: boolean,

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -32,6 +32,7 @@ declare module 'date-fns-tz' {
     firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7
     additionalDigits?: 0 | 1 | 2
     timeZone?: string
+    originalDate?: Date | number
     locale?: Locale
     includeSeconds?: boolean
     addSuffix?: boolean


### PR DESCRIPTION
Fixes https://github.com/marnusw/date-fns-tz/issues/167
Fixes https://github.com/marnusw/date-fns-tz/issues/228

Using the original date for populating the correct replaced timezone token ensures that the DST threshold is applied to the original date, not a pre-modified date used for further formatting.