### PR TITLE
tzTokenizeDate: Remove weird unneeded regex

### DIFF
--- a/src/_lib/tzTokenizeDate/index.js
+++ b/src/_lib/tzTokenizeDate/index.js
@@ -37,7 +37,7 @@ function partsOffset(dtf, date) {
 }
 
 function hackyOffset(dtf, date) {
-  var formatted = dtf.format(date).replace(/\u200E/g, '')
+  var formatted = dtf.format(date)
   var parsed = /(\d+)\/(\d+)\/(\d+),? (\d+):(\d+):(\d+)/.exec(formatted)
   // var [, fMonth, fDay, fYear, fHour, fMinute, fSecond] = parsed
   // return [fYear, fMonth, fDay, fHour, fMinute, fSecond]


### PR DESCRIPTION
According to my tests, format will never display unicode characters.
I ran through every single list of timezones in wikipedia (https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) and not a single time did it ever produce a weird non-ascii output. In fact, putting all possible `dtf.format(date)` in a set and comparing it with:
```javascript
var s = new Set()
/* run through every timezone and do s.add(dtf.format(d)) */
s.forEach(x => console.log(x, x === x.replace(/\u200e/g, '')))
```
Produced exactly the output you would expect:
```
10/24/2023, 24:00:00 true
10/24/2023, 03:00:00 true
10/24/2023, 01:00:00 true
10/24/2023, 02:00:00 true
10/23/2023, 15:00:00 true
10/23/2023, 16:00:00 true
10/23/2023, 20:00:00 true
10/23/2023, 21:00:00 true
10/23/2023, 19:00:00 true
10/23/2023, 18:00:00 true
10/23/2023, 17:00:00 true
10/23/2023, 22:00:00 true
10/23/2023, 21:30:00 true
10/24/2023, 11:00:00 true
10/24/2023, 07:00:00 true
10/24/2023, 10:00:00 true
10/24/2023, 05:00:00 true
10/24/2023, 13:00:00 true
10/24/2023, 06:00:00 true
10/24/2023, 12:00:00 true
10/24/2023, 04:00:00 true
10/24/2023, 08:00:00 true
10/24/2023, 05:30:00 true
10/24/2023, 09:00:00 true
10/24/2023, 04:30:00 true
10/24/2023, 05:45:00 true
10/24/2023, 06:30:00 true
10/24/2023, 03:30:00 true
10/23/2023, 23:00:00 true
10/24/2023, 10:30:00 true
10/24/2023, 09:30:00 true
10/24/2023, 08:45:00 true
10/24/2023, 13:45:00 true
10/23/2023, 14:00:00 true
10/24/2023, 14:00:00 true
10/23/2023, 14:30:00 true
10/23/2023, 13:00:00 true
```
There is no reason to run unecessary regex on ascii strings.