### PR TITLE
lock `date-fns` to 2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "date-fns-tz",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "sideEffects": false,
   "description": "Time zone support for date-fns v2 with the Intl API",
   "author": "Marnus Weststrate <marnusw@gmail.com>",
@@ -120,7 +120,7 @@
     ]
   },
   "peerDependencies": {
-    "date-fns": ">=2.0.0"
+    "date-fns": "2.x"
   },
   "devDependencies": {
     "@babel/cli": "^7.15.4",


### PR DESCRIPTION
This should fix the install of `date-fsn-tz` or at least throw a warn during `npm i`
