### PR TITLE
Specify date-fns 2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "date-fns-tz",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "sideEffects": false,
   "description": "Time zone support for date-fns v2 with the Intl API",
   "author": "Marnus Weststrate <marnusw@gmail.com>",
@@ -120,7 +120,7 @@
     ]
   },
   "peerDependencies": {
-    "date-fns": ">=2.0.0"
+    "date-fns": "2.x"
   },
   "devDependencies": {
     "@babel/cli": "^7.15.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2738,7 +2738,7 @@ __metadata:
     webpack: ^4.41.1
     webpack-cli: ^3.1.2
   peerDependencies:
-    date-fns: ">=2.0.0"
+    date-fns: 2.x
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Same as https://github.com/marnusw/date-fns-tz/pull/262 but has the lockfile updated for CI to pass.

This should fix https://github.com/marnusw/date-fns-tz/issues/260 for date-fns-tz v2 which will still be an issue even [when date-fns-v3 is released](https://github.com/marnusw/date-fns-tz/pull/265).

Example where this will still be an issue after v3 is supported (real scenario from my company):

- shared-library-1 uses date-fns v2 and date-fns-tz v2 (sure they could upgrade, but haven't yet)
- shared-library-2 uses date-fns v3 but does not use date-fns-tz or shared-library-1 so they have no issue
- some-app uses shared-library-1 and shared-library-2
- date-fns-tz v2 (as a dependency of shared-library-1) will attempt to use v3 because it is available and satisfies `>=2.0.0`
- some app will throw an error despite not even using date-fns directly