### PR TITLE
Compatibility with setDefaultOptions in date-fns

### DIFF
--- a/src/_lib/tzIntlTimeZoneName/index.ts
+++ b/src/_lib/tzIntlTimeZoneName/index.ts
@@ -1,4 +1,4 @@
-import type { Locale } from 'date-fns'
+import { getDefaultOptions, type Locale } from 'date-fns'
 import type { FormatOptionsWithTZ } from '../../index.js'
 
 /**
@@ -11,7 +11,8 @@ export function tzIntlTimeZoneName(
   date: Date,
   options: FormatOptionsWithTZ
 ): string | undefined {
-  const dtf = getDTF(length, options.timeZone, options.locale)
+  const defaultOptions = getDefaultOptions()
+  const dtf = getDTF(length, options.timeZone, options.locale ?? defaultOptions.locale)
   return 'formatToParts' in dtf ? partsTimeZone(dtf, date) : hackyTimeZone(dtf, date)
 }
 

--- a/src/_lib/tzIntlTimeZoneName/test.js
+++ b/src/_lib/tzIntlTimeZoneName/test.js
@@ -1,5 +1,7 @@
 import assert from 'power-assert'
 import { tzIntlTimeZoneName } from './index.js'
+import { setDefaultOptions } from 'date-fns'
+import { enGB } from 'date-fns/locale'
 
 describe('tzIntlTimeZoneName', function () {
   it('returns the short time zone name', function () {
@@ -65,5 +67,19 @@ describe('tzIntlTimeZoneName', function () {
     var timeZone = 'Europe/Paris'
     var result = tzIntlTimeZoneName('short', date, { timeZone, locale })
     assert.equal(result, 'GMT+2')
+  })
+
+  describe('setDefaultOptions for locale', function () {
+    it('returns the short time zone name in the specified locale', function () {
+      setDefaultOptions({ locale: enGB })
+      var date = new Date('2014-10-25T13:46:20Z')
+      var timeZone = 'Europe/Paris'
+      var result = tzIntlTimeZoneName('short', date, { timeZone })
+      assert.equal(result, 'CEST')
+    })
+
+    afterEach(() => {
+      setDefaultOptions({ locale: undefined })
+    })
   })
 })

--- a/src/formatInTimeZone/test.js
+++ b/src/formatInTimeZone/test.js
@@ -1,6 +1,7 @@
 import assert from 'power-assert'
-import { enGB } from 'date-fns/locale/en-GB'
 import { formatInTimeZone } from './index.js'
+import { setDefaultOptions } from 'date-fns'
+import { vi, enGB, de } from 'date-fns/locale'
 
 describe('formatInTimeZone', function () {
   it('treat date only string in the timezone specified in the options', function () {
@@ -114,5 +115,59 @@ describe('formatInTimeZone', function () {
       formatInTimeZone.bind(null, date, 'bad/timezone', "dd.MM.yyyy HH:mm 'UTC'xxx"),
       RangeError
     )
+  })
+
+  describe('setDefaultOptions for locale', function () {
+    var date = '1986-04-04T10:32:55.123Z'
+    var timeZone = 'Europe/Paris'
+    var format = "PPPP 'UTC'xxx"
+    var tests = [
+      {
+        expected: 'Freitag, 4. April 1986 UTC+02:00',
+        locale: de,
+      },
+      {
+        expected: 'Thứ Sáu, ngày 4 tháng 04 năm 1986 UTC+02:00',
+        locale: vi,
+      },
+    ]
+
+    tests.forEach(function (test) {
+      it(`locale: ${test.locale.code}`, function () {
+        setDefaultOptions({ locale: test.locale })
+        assert.equal(formatInTimeZone(date, timeZone, format), test.expected)
+      })
+    })
+
+    afterEach(() => {
+      setDefaultOptions({ locale: undefined })
+    })
+  })
+
+  describe('setDefaultOptions for locale using tzIntlTimeZoneName', function () {
+    var date = '1986-04-04T10:32:55.123Z'
+    var timeZone = 'Europe/Paris'
+    var format = 'dd.MM.yyyy HH:mm zzzz'
+    var tests = [
+      {
+        expected: '04.04.1986 12:32 Mitteleuropäische Sommerzeit',
+        locale: de,
+      },
+      {
+        expected: '04.04.1986 12:32 Giờ mùa hè Trung Âu',
+        locale: vi,
+      },
+    ]
+
+    tests.forEach(function (test) {
+      it(`locale: ${test.locale.code}`, function () {
+        setDefaultOptions({ locale: test.locale })
+        assert.equal(formatInTimeZone(date, timeZone, format), test.expected)
+      })
+    })
+
+    afterEach(() => {
+      setDefaultOptions({ locale: undefined })
+    })
   })
 })


### PR DESCRIPTION
Resolves #233

`tzIntlTimeZoneName` was the only place I found that was affected by `setDefaultOptions`