### PR TITLE
feat: enable webpack federated modules

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -1,3 +1,5 @@
 {
+  "name": "date-fns-tz",
+  "version": "3.2.0",
   "type": "module"
 }


### PR DESCRIPTION
This PR resolves issue [#308](https://github.com/marnusw/date-fns-tz/issues/308) and enables Webpack federated modules to determine the correct version of `date-fns-tz` to use.