### PR TITLE
Fix date-fns import that pulls in entire library in consuming apps

### DIFF
--- a/src/_lib/tzIntlTimeZoneName/index.ts
+++ b/src/_lib/tzIntlTimeZoneName/index.ts
@@ -1,4 +1,5 @@
-import { getDefaultOptions, type Locale } from 'date-fns'
+import { getDefaultOptions } from 'date-fns/getDefaultOptions'
+import type { Locale } from 'date-fns'
 import type { FormatOptionsWithTZ } from '../../index.js'
 
 /**


### PR DESCRIPTION
I recently bumped date-fns up to v4 for a client and upgraded to `3.2.0` of this library as well. In the process, the entire `date-fns` library started getting pulled in, although we'd very carefully worked to ensure we were importing just the pieces we needed (and had made sure that was working).

It took a bit of digging, but it turns out the addition of the `getDefaultOptions` import as part of the 3.2.0 upgrade led to the entire `date-fns` library getting pulled in, as the import from the main barrel file of `date-fns` then means that consumers can't tree-shake properly.

This two-line patch gets this app's bundle size back where we expected.

Thanks for your work on this library over the years, it's been much appreciated!