### PR TITLE
s/consty/vary/ typo

### DIFF
--- a/src/format/index.ts
+++ b/src/format/index.ts
@@ -11,7 +11,7 @@ const tzFormattingTokensRegExp = /([xXOz]+)|''|'(''|[^'])+('|$)/g
  * @summary Format the date.
  *
  * @description
- * Return the formatted date string in the given format. The result may consty by locale.
+ * Return the formatted date string in the given format. The result may vary by locale.
  *
  * > ⚠️ Please note that the `format` tokens differ from Moment.js and other libraries.
  * > See: https://git.io/fxCyr


### PR DESCRIPTION
Was accidentally changed from "vary" in bulk var->const replacements during [TypeScript conversion #278](https://github.com/marnusw/date-fns-tz/pull/278/files#diff-7b1dbecd4320b0086a9c54676a8d78a90ab1e5b6155296091887aa19e47834f2L10-L14) :grin: