### PR TITLE
feat: Add function to calculate DST offset for a given date and timezone

### DIFF
--- a/src/getDaylightSavingTimeOffset/index.ts
+++ b/src/getDaylightSavingTimeOffset/index.ts
@@ -1,0 +1,36 @@
+import { fromZonedTime } from '../fromZonedTime/index.js'
+import { getTimezoneOffset } from '../getTimezoneOffset/index.js'
+
+/**
+ * @name getDaylightSavingTimeOffset
+ * @category Time Zone Helpers
+ * @summary Calculates the Daylight Saving Time (DST) offset in minutes for a specific date and timezone.
+ *
+ * @description
+ * Returns the DST offset (in minutes) for a given date/timezone.
+ * Scans offsets for all 12 months and picks the smallest as the standard.
+ * Typically accurate for most modern DST rules globally.
+ *
+ * @param {Date} date - the date to calculate the DST offset for
+ * @param {string} timezone - the timezone, either an IANA timezone or timezone offset
+ */
+
+export function getDaylightSavingTimeOffset(date: Date, timezone: string): number {
+  // convert incoming date to zoned time based on given timezone
+  const zonedDate = fromZonedTime(date, timezone)
+  const thisYear = zonedDate.getFullYear()
+  // get current timezone offset for the given date
+  const currentOffset = getTimezoneOffset(timezone, zonedDate)
+  /**
+   * Iterate through each month to determine the standard (non-DST) timezone offset by selecting the min offset value
+   * Assumes the standard offset is the smallest, typically representing the base offset w/o DST
+   */
+  let minOffset = Infinity
+  for (let month = 0; month < 12; month++) {
+    const offset = getTimezoneOffset(timezone, new Date(thisYear, month, 1))
+    if (offset < minOffset) minOffset = offset
+  }
+
+  // calculate DST offset as the difference from standard
+  return (currentOffset - minOffset) / (60 * 1000)
+}

--- a/src/getDaylightSavingTimeOffset/test.js
+++ b/src/getDaylightSavingTimeOffset/test.js
@@ -1,0 +1,35 @@
+/* eslint-env mocha */
+import assert from 'power-assert'
+import { getDaylightSavingTimeOffset } from './index.js'
+
+describe('getDaylightSavingTimeOffset', () => {
+  it('returns 0 for UTC (no DST)', () => {
+    const date = new Date('2025-03-15T00:00:00Z')
+    assert.equal(getDaylightSavingTimeOffset(date, 'UTC'), 0)
+  })
+
+  it('detects DST in northern hemisphere summer (New York)', () => {
+    const date = new Date('2025-07-01T12:00:00Z')
+    assert.equal(getDaylightSavingTimeOffset(date, 'America/New_York'), 60)
+  })
+
+  it('returns 0 in northern hemisphere winter (New York)', () => {
+    const date = new Date('2025-01-15T12:00:00Z')
+    assert.equal(getDaylightSavingTimeOffset(date, 'America/New_York'), 0)
+  })
+
+  it('detects DST in southern hemisphere summer (Sydney)', () => {
+    const date = new Date('2025-01-15T12:00:00Z')
+    assert.equal(getDaylightSavingTimeOffset(date, 'Australia/Sydney'), 60)
+  })
+
+  it('returns 0 in southern hemisphere winter (Sydney)', () => {
+    const date = new Date('2025-07-15T12:00:00Z')
+    assert.equal(getDaylightSavingTimeOffset(date, 'Australia/Sydney'), 0)
+  })
+
+  it('shows 0 for a zone without DST (Africa/Johannesburg)', () => {
+    const date = new Date('2025-06-15T12:00:00Z')
+    assert.equal(getDaylightSavingTimeOffset(date, 'Africa/Johannesburg'), 0)
+  })
+})

--- a/src/getDaylightSavingTimeOffset/test.js
+++ b/src/getDaylightSavingTimeOffset/test.js
@@ -1,4 +1,3 @@
-/* eslint-env mocha */
 import assert from 'power-assert'
 import { getDaylightSavingTimeOffset } from './index.js'
 


### PR DESCRIPTION
This PR adds a new utility function, getDaylightSavingTimeOffset, to calculate the DST offset, in minutes, for a given date and timezone. It should address issue [#304](https://github.com/marnusw/date-fns-tz/issues/304). This should work for most standard cases, and I've provided a few tests.