### PR TITLE
Fix format import from date-fns

### DIFF
--- a/src/format/index.ts
+++ b/src/format/index.ts
@@ -1,4 +1,4 @@
-import { format as dateFnsFormat } from 'date-fns/format'
+import { format as dateFnsFormat } from 'date-fns'
 import { formatters } from './formatters/index.js'
 import { toDate } from '../toDate/index.js'
 import type { FormatOptionsWithTZ } from '../index.js'


### PR DESCRIPTION
### Error Occur while building ssr package
- 1:[vite-plugin-pwa:build] "format" is not exported by "node_modules/date-fns/esm/format/index.js", imported by "node_modules/date-fns-tz/dist/esm/format/index.js". file: D:/personal/onewo.ai/packages/renderer/tools/node_modules/date-fns-tz/dist/esm/format/index.js:1:9 1: import { format as dateFnsFormat } from 'date-fns/format';
            ^
- 2: import { formatters } from './formatters/index.js'; 3: import { toDate } from '../toDate/index.js';
error during build:

## RollupError: 
"format" is not exported by "node_modules/date-fns/esm/format/index.js", imported by "node_modules/date-fns-tz/dist/esm/format/index.js".